### PR TITLE
Use matrices to convert between skeletons

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
   - pytest=5.2.0
   - pytest-mock=1.11.2
   - hypothesis=4.44.2
-  - toolz=0.10.0
   - pip:
     - phx-class-registry==3.0.5
     - tvl-backends-nvdec==0.1.0b18

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,5 @@ setup(
     install_requires=[
         'numpy',
         'phx-class-registry',
-        'toolz',
     ]
 )

--- a/src/posekit/skeleton/converter.py
+++ b/src/posekit/skeleton/converter.py
@@ -1,49 +1,76 @@
+from typing import Optional, Dict
+
+import numpy as np
+
+from glupy.utils import is_torch_tensor, as_torch_tensor
 from . import skeleton_registry
 from .utils import assert_plausible_skeleton
-
-from toolz.functoolz import identity, compose
 
 
 class _ConversionRegistry:
     def __init__(self):
-        self._functions = {}
+        self._matrices = {}
 
-    def register(self, from_skeleton_name: str, to_skeleton_name: str):
-        def decorator(func):
-            def augmented_func(joints):
-                from_skeleton = skeleton_registry[from_skeleton_name]
-                to_skeleton = skeleton_registry[to_skeleton_name]
-                assert_plausible_skeleton(joints, from_skeleton)
-                new_joints = func(joints, from_skeleton, to_skeleton)
-                assert_plausible_skeleton(new_joints, to_skeleton)
-                return new_joints
-            self._functions.setdefault(from_skeleton_name, {})[to_skeleton_name] = augmented_func
-            return func
-        return decorator
+    def register_matrix(self, from_skeleton_name: str, to_skeleton_name: str, mat: np.ndarray):
+        """Register a conversion matrix.
+        """
+        from_skeleton = skeleton_registry[from_skeleton_name]
+        to_skeleton = skeleton_registry[to_skeleton_name]
+        if mat.shape != (from_skeleton.n_joints, to_skeleton.n_joints):
+            raise ValueError(f'expected a {from_skeleton.n_joints} x {to_skeleton.n_joints} matrix')
+        self._matrices.setdefault(from_skeleton_name, {})[to_skeleton_name] = mat
 
-    def _compose_conversion_functions(self, from_skeleton_name: str, to_skeleton_name: str):
+    def create_matrix(
+        self,
+        from_skeleton_name: str,
+        to_skeleton_name: str,
+        joint_map: Optional[Dict[str, Dict[str, float]]] = None,
+    ):
+        """Create and register a new conversion matrix.
+        """
+        from_skeleton = skeleton_registry[from_skeleton_name]
+        to_skeleton = skeleton_registry[to_skeleton_name]
+        if joint_map is None:
+            joint_map = {}
+        mat = np.zeros((from_skeleton.n_joints, to_skeleton.n_joints))
+        for j, joint_name in enumerate(to_skeleton.joint_names):
+            if joint_name in joint_map:
+                for src_joint_name, src_joint_weight in joint_map[joint_name].items():
+                    mat[from_skeleton.joint_index(src_joint_name), j] = src_joint_weight
+            elif joint_name in from_skeleton.joint_names:
+                mat[from_skeleton.joint_index(joint_name), j] = 1.0
+        self.register_matrix(from_skeleton_name, to_skeleton_name, mat)
+        return mat
+
+    def conversion_matrix(self, from_skeleton_name: str, to_skeleton_name: str):
+        """Get a conversion matrix for mapping from one skeleton to another.
+
+        If no direct conversion matrix has been defined previously, this function will attempt
+        to compose conversion matrices.
+        """
         if from_skeleton_name == to_skeleton_name:
-            return identity
-        try:
-            queue = list(self._functions[from_skeleton_name].items())
-        except KeyError:
-            queue = []
+            return np.eye(skeleton_registry[from_skeleton_name].n_joints)
+        queue = list(self._matrices.get(from_skeleton_name, {}).items())
         seen = {from_skeleton_name}
         while len(queue) > 0:
-            skeleton_name, func = queue.pop()
+            skeleton_name, mat = queue.pop()
             if skeleton_name == to_skeleton_name:
-                return func
+                return mat
             seen.add(skeleton_name)
-            try:
-                for next_skeleton_name, next_func in self._functions[skeleton_name].items():
-                    if next_skeleton_name not in seen:
-                        queue.insert(0, (next_skeleton_name, compose(next_func, func)))
-            except KeyError:
-                pass
+            for next_skeleton_name, next_mat in self._matrices.get(skeleton_name, {}).items():
+                if next_skeleton_name not in seen:
+                    queue.insert(0, (next_skeleton_name, mat @ next_mat))
         raise NotImplementedError(f'no skeleton conversion path defined from {from_skeleton_name} to {to_skeleton_name}')
 
     def convert(self, joints, from_skeleton_name: str, to_skeleton_name: str):
-        return self._compose_conversion_functions(from_skeleton_name, to_skeleton_name)(joints)
+        """Convert joint keypoints from one skeleton to another.
+        """
+        assert_plausible_skeleton(joints, skeleton_registry[from_skeleton_name])
+        mat = self.conversion_matrix(from_skeleton_name, to_skeleton_name)
+        new_joints = np.einsum('...ij,ik->...kj', np.asarray(joints, dtype=np.float32), mat)
+        if is_torch_tensor(joints):
+            new_joints = as_torch_tensor(new_joints)
+        return new_joints
 
 
 skeleton_converter = _ConversionRegistry()

--- a/src/posekit/skeleton/converter.py
+++ b/src/posekit/skeleton/converter.py
@@ -67,9 +67,9 @@ class _ConversionRegistry:
         """
         assert_plausible_skeleton(joints, skeleton_registry[from_skeleton_name])
         mat = self.conversion_matrix(from_skeleton_name, to_skeleton_name)
-        new_joints = np.einsum('...ij,ik->...kj', np.asarray(joints, dtype=np.float32), mat)
+        new_joints = np.einsum('...ij,ik->...kj', np.asarray(joints), mat)
         if is_torch_tensor(joints):
-            new_joints = as_torch_tensor(new_joints)
+            new_joints = as_torch_tensor(new_joints).to(joints)
         return new_joints
 
 

--- a/src/posekit/skeleton/utils.py
+++ b/src/posekit/skeleton/utils.py
@@ -9,16 +9,6 @@ def assert_plausible_skeleton(joints, skeleton: Skeleton):
     assert joints.shape[-2] == skeleton.n_joints
 
 
-def move_joint_closer_(joints, skeleton: Skeleton, joint_name, other_joint_name, alpha):
-    joints[..., skeleton.joint_index(joint_name), :] *= (1 - alpha)
-    joints[..., skeleton.joint_index(joint_name), :] += alpha * joints[..., skeleton.joint_index(other_joint_name), :]
-
-
-def move_joint_farther_(joints, skeleton: Skeleton, joint_name, other_joint_name, alpha):
-    joints[..., skeleton.joint_index(joint_name), :] -= alpha * joints[..., skeleton.joint_index(other_joint_name), :]
-    joints[..., skeleton.joint_index(joint_name), :] /= (1 - alpha)
-
-
 def procrustes(ref_points, cor_points, points=None, *, reflection=False):
     """Align `cor_points` to `ref_points`, and apply the resulting transformation to `points`.
 


### PR DESCRIPTION
Prior to this PR skeleton conversion was handled by using functions which take 2D or 3D joint location arrays as input. All existing conversion functions simply performed a linear mapping of the joints from the source skeleton representation to the target.

This PR changes the skeleton converter so that it uses conversion matrices instead. This offers greater flexibility for users of posekit, as the matrices can be used for other purposes (e.g. transforming joint visibility arrays or network output layers).